### PR TITLE
Set fill mode and dbus address

### DIFF
--- a/bin/setwallpaper_kde
+++ b/bin/setwallpaper_kde
@@ -32,7 +32,10 @@ for (i=0;i<Desktops.length;i++)
     d.currentConfigGroup = Array('Wallpaper', '${type}', 'General');
     d.writeConfig('Image', 'file:///dev/null')
     d.writeConfig('$write', 'file://${full_image_path}')
+    d.writeConfig('FillMode', 2)
 }"
+
+pid=$(pgrep -xn plasmashell) && export DBUS_SESSION_BUS_ADDRESS="$(grep -ao -m1 -P '(?<=DBUS_SESSION_BUS_ADDRESS=).*?\0' /proc/"$pid"/environ)"
 
 # Set wallpaper.
 qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "${wallpaper_set_script}"


### PR DESCRIPTION
This PR changes 2 things:

- It sets the fill mode of the background image to fill centered.
- It gets the dbus address if the environment variable has not been set.